### PR TITLE
fix: update easy motion url

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -33,7 +33,7 @@ silent! if plug#begin('~/.vim/plugged')
         Plug 'terryma/vim-multiple-cursors'
         Plug 'maxbrunsfeld/vim-yankstack'
         Plug 'terryma/vim-expand-region'
-        Plug 'Lokaltog/vim-easymotion'
+        Plug 'easymotion/vim-easymotion'
         Plug 'Raimondi/delimitMate'
         Plug 'scrooloose/syntastic'
         Plug 'tomtom/tcomment_vim'


### PR DESCRIPTION
The project is taken over `Lokaltog`, so update the plugin name.